### PR TITLE
-lrt loader switch is needed on raspbian wheezy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 # ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
 # MIX		path to mix
 
-LDFLAGS +=
+LDFLAGS += -lrt
 CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter
 CFLAGS += -std=c99 -D_GNU_SOURCE
 CC ?= $(CROSSCOMPILER)gcc

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,11 @@
 # ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
 # MIX		path to mix
 
-LDFLAGS += -lrt
+LDFLAGS +=
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+  LdFLAGS += -lrt
+endif
 CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter
 CFLAGS += -std=c99 -D_GNU_SOURCE
 CC ?= $(CROSSCOMPILER)gcc

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,14 @@
 # MIX		path to mix
 
 LDFLAGS +=
+
+# -lrt is needed for clock_gettime() on linux with glibc before version 2.17
+# (for example raspbian wheezy)
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
   LdFLAGS += -lrt
 endif
+
 CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter
 CFLAGS += -std=c99 -D_GNU_SOURCE
 CC ?= $(CROSSCOMPILER)gcc

--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,6 @@
 # MIX		path to mix
 
 LDFLAGS +=
-
-# -lrt is needed for clock_gettime() on linux with glibc before version 2.17
-# (for example raspbian wheezy)
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Linux)
-  LdFLAGS += -lrt
-endif
-
 CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter
 CFLAGS += -std=c99 -D_GNU_SOURCE
 CC ?= $(CROSSCOMPILER)gcc
@@ -48,6 +40,13 @@ EXEEXT=.exe
 
 else
 # Non-Windows
+
+# -lrt is needed for clock_gettime() on linux with glibc before version 2.17
+# (for example raspbian wheezy)
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+  LDFLAGS += -lrt
+endif
 
 # Look for the EI library and header files
 # For crosscompiled builds, ERL_EI_INCLUDE_DIR and ERL_EI_LIBDIR must be


### PR DESCRIPTION
Raspbian wheezy ships with glibc version 2.13 so it needs the -lrt switch to use the clock_gettime function. Based on very limited testing, having the switch does not seem hurt on later versions of glibc (linux) but it would not be necessary. 