### PR TITLE
Flush framing when closing a port

### DIFF
--- a/lib/nerves_uart.ex
+++ b/lib/nerves_uart.ex
@@ -314,8 +314,9 @@ defmodule Nerves.UART do
     response = call_port(state, :close, nil)
 
     # Clean up the Elixir side
+    new_framing_state = apply(state.framing, :flush, [:both, state.framing_state])
     new_state = handle_framing_timer(
-      %{state | name: nil, framing_state: nil, queued_messages: []},
+      %{state | name: nil, framing_state: new_framing_state, queued_messages: []},
       :ok
     )
 

--- a/test/basic_uart_test.exs
+++ b/test/basic_uart_test.exs
@@ -177,6 +177,45 @@ defmodule BasicUARTTest do
     UART.close(uart2)
   end
 
+  test "error writing to a closed port", %{uart1: uart1, uart2: uart2} do
+    assert :ok = UART.open(uart2, UARTTest.port2, active: false)
+
+    # port1 not yet opened
+    assert {:error, :ebadf} = UART.write(uart1, "A")
+
+    # port1 opened
+    assert :ok = UART.open(uart1, UARTTest.port1, active: false)
+    assert :ok = UART.write(uart1, "A")
+    assert {:ok, "A"} = UART.read(uart2)
+
+    # port1 closed
+    assert :ok = UART.close(uart1)
+    assert {:error, :ebadf} = UART.write(uart1, "B")
+
+    UART.close(uart1)
+    UART.close(uart2)
+  end
+
+  test "error writing to a closed port when using framing", %{uart1: uart1, uart2: uart2} do
+    framing = {UART.Framing.Line, separator: "\n"}
+    assert :ok = UART.open(uart2, UARTTest.port2, active: false, framing: framing)
+
+    # port1 not yet opened
+    assert {:error, :ebadf} = UART.write(uart1, "A")
+
+    # port1 opened
+    assert :ok = UART.open(uart1, UARTTest.port1, active: false, framing: framing)
+    assert :ok = UART.write(uart1, "A")
+    assert {:ok, "A"} = UART.read(uart2)
+
+    # port1 closed
+    assert :ok = UART.close(uart1)
+    assert {:error, :ebadf} = UART.write(uart1, "B")
+
+    UART.close(uart1)
+    UART.close(uart2)
+  end
+
   test "active mode receive", %{uart1: uart1, uart2: uart2} do
     assert :ok = UART.open(uart1, UARTTest.port1, active: false)
     assert :ok = UART.open(uart2, UARTTest.port2, active: true)


### PR DESCRIPTION
Aims to fix the following issue:
## Repro Steps
On master,
1. Open a port with `framing`, e.g.
```elixir
Nerves.UART.open(uart1, path, framing: Nerves.UART.Framing.Line)
```
2. Close the port
```elixir
Nerves.UART.close(uart1)
```
3. Attempt to write to the closed port
```elixir
Nerves.UART.write(uart, "A")
```

**expected (this branch)**
`{:error, :ebadf}`

**actual**
```
16:02:14.974 [error] GenServer #PID<0.180.0> terminating
** (UndefinedFunctionError) function nil.separator/0 is undefined (module nil is not available)
    nil.separator()
    (nerves_uart) lib/uart/framing/line.ex:45: Nerves.UART.Framing.Line.add_framing/2
    (nerves_uart) lib/nerves_uart.ex:357: Nerves.UART.handle_call/3
    (stdlib) gen_server.erl:636: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:665: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Last message (from #PID<0.179.0>): {:write, "B", 5000}
State: %Nerves.UART.State{controlling_process: #PID<0.179.0>, framing: Nerves.UART.Framing.Line, framing_state: nil, is_active: false, name: nil, port: #Port<0.4991>, queued_messages: [], rx_framing_timeout: 0, rx_framing_tref: nil}
```
When closing, the `framing_state` is set to `nil`, but `framing` is left intact (`Nerves.UART.Framing.Line`)
The second test I added breaks in master with this error, but passes on this branch.

## Proposed solution
The goal is to reset the `framing_state` when closing, rather than clearing it to `nil`. When we clear it to `nil` we lose info about the Framing options, e.g. `:separator`.

Flushing the framing clears the `:processed` and `:in_process` binary while leaving the client-supplied options intact.

---

I'm not certain flushing is the best long-term approach however as the `flush` callback now has the added the responsibility of knowing what to do when the port is closed. So perhaps when closing you could do something like
```elixir
new_framing_state = apply(state.framing, :reset, [state.framing_state])
```
where `:reset` is a Framing callback.
[Here is the diff of a separate branch](https://github.com/nerves-project/nerves_uart/compare/master...johnc219:fix/write-to-closed-port-with-framing-2) that fixes this issue with this `reset` approach instead. I'm guessing that would break anyone who's implemented their own framings though, so it would require a major version bump. Therefore i _**think**_ the `flush` approach is the (possibly less correct) safer alternative.

## Current workaround
After closing i explicitly configure the uart like such:
```elixirt
Nerves.UART.configure(framing: Nerves.UART.Framing.None)
```