### PR TITLE
Passive mode configuration is not honored on open when port is not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,3 @@ erl_crash.dump
 
 # Ignore debug logs
 nerves_uart.log
-
-# IntelliJ
-/.idea
-.iml

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ erl_crash.dump
 
 # Ignore debug logs
 nerves_uart.log
+
+# IntelliJ
+/.idea
+.iml

--- a/src/uart_comm_win.c
+++ b/src/uart_comm_win.c
@@ -386,8 +386,18 @@ int uart_is_open(struct uart *port)
 
 int uart_configure(struct uart *port, const struct uart_config *config)
 {
-    // Update active mode
+    bool active_mode_changed = false;
     if (config->active != port->active_mode_enabled) {
+      port->active_mode_enabled = config->active;
+      active_mode_changed = true;
+    }
+
+    // Updating closed ports is easy.
+    if (port->h == NULL)
+        return 0;
+
+    // Update active mode
+    if (active_mode_changed) {
         if (port->read_pending)
             errx(EXIT_FAILURE, "Elixir is supposed to queue read ops");
 
@@ -408,10 +418,6 @@ int uart_configure(struct uart *port, const struct uart_config *config)
                 errx(EXIT_FAILURE, "uart_configure: SetCommMask failure unexpected: 0x%08x, Error=%d", (int) port->desired_event_mask, (int) GetLastError());
         }
     }
-
-    // Updating closed ports is easy.
-    if (port->h == NULL)
-        return 0;
 
     if (uart_config_line(port, config) < 0) {
         debug("uart_config_line failed");

--- a/test/basic_uart_test.exs
+++ b/test/basic_uart_test.exs
@@ -196,33 +196,39 @@ defmodule BasicUARTTest do
     UART.close(uart2)
   end
 
-  test "error message on open is reported when active mode is configured explicitly", %{uart1: uart1} do
+  test "error message on open is reported when active mode is configured explicitly", %{
+    uart1: uart1
+  } do
     :ok = UART.configure(uart1, active: true)
-    {:error, :enoent} = UART.open(uart1, UARTTest.port1()<>"_does_not_exist")
+    {:error, :enoent} = UART.open(uart1, UARTTest.port1() <> "_does_not_exist")
     assert_receive {:nerves_uart, _port, {:error, :ebadf}}
   end
 
   test "error message on open is reported when active mode is configured on open", %{uart1: uart1} do
-    {:error, :enoent} = UART.open(uart1, UARTTest.port1()<>"_does_not_exist", active: true)
+    {:error, :enoent} = UART.open(uart1, UARTTest.port1() <> "_does_not_exist", active: true)
     assert_receive {:nerves_uart, _port, {:error, :ebadf}}
   end
 
-  test "error message on open is only reported to read/write call when passive mode is configured explicitly", %{uart1: uart1} do
+  test "error message on open is only reported to read/write call when passive mode is configured explicitly",
+       %{uart1: uart1} do
     :ok = UART.configure(uart1, active: false)
-    {:error, :enoent} = UART.open(uart1, UARTTest.port1()<>"_does_not_exist")
+    {:error, :enoent} = UART.open(uart1, UARTTest.port1() <> "_does_not_exist")
 
     receive do
-      {:nerves_uart, _port, {:error, :ebadf}} -> flunk("Error messages should only be reported on read/write calls in passive mode")
+      {:nerves_uart, _port, {:error, :ebadf}} ->
+        flunk("Error messages should only be reported on read/write calls in passive mode")
     after
       0 -> :ok
     end
   end
 
-  test "error message on open is only reported to read/write call when passive mode is configured on open", %{uart1: uart1} do
-    {:error, :enoent} = UART.open(uart1, UARTTest.port1()<>"_does_not_exist", active: false)
+  test "error message on open is only reported to read/write call when passive mode is configured on open",
+       %{uart1: uart1} do
+    {:error, :enoent} = UART.open(uart1, UARTTest.port1() <> "_does_not_exist", active: false)
 
     receive do
-      {:nerves_uart, _port, {:error, :ebadf}} -> flunk("Error messages should only be reported on read/write calls in passive mode")
+      {:nerves_uart, _port, {:error, :ebadf}} ->
+        flunk("Error messages should only be reported on read/write calls in passive mode")
     after
       0 -> :ok
     end

--- a/test/basic_uart_test.exs
+++ b/test/basic_uart_test.exs
@@ -196,7 +196,18 @@ defmodule BasicUARTTest do
     UART.close(uart2)
   end
 
-  test "error message is only reported to read/write call when passive mode is configured explicitly", %{uart1: uart1} do
+  test "error message on open is reported when active mode is configured explicitly", %{uart1: uart1} do
+    :ok = UART.configure(uart1, active: true)
+    {:error, :enoent} = UART.open(uart1, UARTTest.port1()<>"_does_not_exist")
+    assert_receive {:nerves_uart, _port, {:error, :ebadf}}
+  end
+
+  test "error message on open is reported when active mode is configured on open", %{uart1: uart1} do
+    {:error, :enoent} = UART.open(uart1, UARTTest.port1()<>"_does_not_exist", active: true)
+    assert_receive {:nerves_uart, _port, {:error, :ebadf}}
+  end
+
+  test "error message on open is only reported to read/write call when passive mode is configured explicitly", %{uart1: uart1} do
     :ok = UART.configure(uart1, active: false)
     {:error, :enoent} = UART.open(uart1, UARTTest.port1()<>"_does_not_exist")
 
@@ -207,7 +218,7 @@ defmodule BasicUARTTest do
     end
   end
 
-  test "error message is only reported to read/write call when passive mode is configured on open", %{uart1: uart1} do
+  test "error message on open is only reported to read/write call when passive mode is configured on open", %{uart1: uart1} do
     {:error, :enoent} = UART.open(uart1, UARTTest.port1()<>"_does_not_exist", active: false)
 
     receive do


### PR DESCRIPTION
When a UART.open request is made for a port that is not yet available, the uart_open and uart_process functions return before the active mode configuration is applied.  This behavior causes a {:nerves_uart, _port, {:error, :ebadf} error message to be sent back to the calling process, which is only expected when active mode is configured.