### PR TITLE
uart_comm_win: reenable polling after EV_RXCHAR

### DIFF
--- a/src/uart_comm_win.c
+++ b/src/uart_comm_win.c
@@ -744,6 +744,9 @@ void uart_process_handle(struct uart *port, HANDLE *event)
                 // to EV_RXCHAR.
                 if (!(port->received_event_mask & EV_RXCHAR)) {
                     debug("spurious EV_RXCHAR");
+                    if (port->active_mode_enabled) {
+                        start_async_reads(port);
+                    }
                     return;
                 }
 


### PR DESCRIPTION
a spurious EV_RXCHAR event stopps anync reading.
restart the polling by calling start_async_reads.