### PR TITLE
Pid id messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,25 @@ iex> flush
 {:nerves_uart, "COM14", {:partial, "A"}}
 ```
 
+Sometimes it's easier to just operate with the `pid` of the Nerves GenServer
+rather than using the name of the port in active mode. An example of this is
+when you want to send data back to the port after receiving some data, and when
+dealing with many serial ports at once. You can do this with the `id: :pid`
+option to `open/1` or `configure/1`.
+
+```elixir
+iex> Nerves.UART.configure(pid, id: :pid)
+:ok
+
+# Assume some data was received
+
+iex> receive do
+...>   {:nerves_uart, pid, _} ->
+...>     Nerves.UART.write pid, "def"
+...> end
+:ok
+```
+
 ## Installation
 
 To install `nerves_uart`:

--- a/lib/nerves_uart.ex
+++ b/lib/nerves_uart.ex
@@ -407,10 +407,11 @@ defmodule Nerves.UART do
     new_framing = Keyword.get(opts, :framing, nil)
     new_rx_framing_timeout = Keyword.get(opts, :rx_framing_timeout, state.rx_framing_timeout)
     is_active = Keyword.get(opts, :active, state.is_active)
+    id_mode = Keyword.get(opts, :id, state.id)
 
     state =
       change_framing(
-        %{state | rx_framing_timeout: new_rx_framing_timeout, is_active: is_active},
+        %{state | rx_framing_timeout: new_rx_framing_timeout, is_active: is_active, id: id_mode},
         new_framing
       )
 

--- a/lib/nerves_uart.ex
+++ b/lib/nerves_uart.ex
@@ -319,6 +319,7 @@ defmodule Nerves.UART do
     new_framing = Keyword.get(opts, :framing, nil)
     new_rx_framing_timeout = Keyword.get(opts, :rx_framing_timeout, state.rx_framing_timeout)
     is_active = Keyword.get(opts, :active, true)
+    id_mode = Keyword.get(opts, :id, :name)
 
     response = call_port(state, :open, {name, opts})
 
@@ -329,7 +330,8 @@ defmodule Nerves.UART do
           | name: name,
             controlling_process: from_pid,
             rx_framing_timeout: new_rx_framing_timeout,
-            is_active: is_active
+            is_active: is_active,
+            id: id_mode
         },
         new_framing
       )


### PR DESCRIPTION
This is tested to work on my machine. It adds an extra option to get pids instead of serial port names in active mode.