### PR TITLE
Add helper function for finding UARTs and getting their configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.2.0-dev
+
+  * Improvements
+    * Added `find_pids/0` diagnostic utility for finding lost `Nerves.UART` pids.
+      This is handy when you need to close a serial port and don't know the pid.
+    * Added `configuration/1` to get the current configuration of a UART.
+
 ## v1.1.1
 
 The mix.exs file has the Elixir requirement bumped from 1.3 to 1.4. This was

--- a/lib/nerves_uart.ex
+++ b/lib/nerves_uart.ex
@@ -174,6 +174,14 @@ defmodule Nerves.UART do
   end
 
   @doc """
+  Get the configuration of the serial port.
+  """
+  @spec configuration(GenServer.server()) :: {binary, [uart_option]}
+  def configuration(pid) do
+    GenServer.call(pid, :configuration)
+  end
+
+  @doc """
   Send a continuous stream of zero bits for a duration in milliseconds.
   By default, the zero bits are transmitted at least 0.25 seconds.
 
@@ -337,6 +345,19 @@ defmodule Nerves.UART do
       )
 
     {:reply, response, new_state}
+  end
+
+  def handle_call(:configuration, _from, state) do
+    opts =
+      call_port(state, :configuration, {}) ++
+        [
+          active: state.is_active,
+          id: state.id,
+          rx_framing_timeout: state.rx_framing_timeout,
+          framing: state.framing
+        ]
+
+    {:reply, {state.name, opts}, state}
   end
 
   def handle_call(:close, _from, state) do

--- a/lib/nerves_uart.ex
+++ b/lib/nerves_uart.ex
@@ -30,7 +30,7 @@ defmodule Nerves.UART do
     # is_active: active or passive mode
     defstruct port: nil,
               controlling_process: nil,
-              name: nil,
+              name: :closed,
               framing: Nerves.UART.Framing.None,
               framing_state: nil,
               rx_framing_timeout: 0,
@@ -86,7 +86,7 @@ defmodule Nerves.UART do
   NOTE: Do not rely on this function in production code. It may change if
   updates to the interface make it more convenient to use.
   """
-  @spec find_pids() :: [{binary, pid()}]
+  @spec find_pids() :: [{binary | :closed, pid()}]
   def find_pids() do
     Process.list()
     |> Enum.filter(&is_nerves_uart_process/1)
@@ -205,7 +205,7 @@ defmodule Nerves.UART do
   @doc """
   Get the configuration of the serial port.
   """
-  @spec configuration(GenServer.server()) :: {binary, [uart_option]}
+  @spec configuration(GenServer.server()) :: {binary() | :closed, [uart_option]}
   def configuration(pid) do
     GenServer.call(pid, :configuration)
   end
@@ -398,7 +398,7 @@ defmodule Nerves.UART do
 
     new_state =
       handle_framing_timer(
-        %{state | name: nil, framing_state: new_framing_state, queued_messages: []},
+        %{state | name: :closed, framing_state: new_framing_state, queued_messages: []},
         :ok
       )
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Nerves.UART.MixProject do
   use Mix.Project
 
-  @version "1.1.1"
+  @version "1.2.0-dev"
 
   @description "Discover and use UARTs and serial ports in Elixir."
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule Nerves.UART.Mixfile do
+defmodule Nerves.UART.MixProject do
   use Mix.Project
 
   @version "1.1.1"

--- a/src/nerves_uart.c
+++ b/src/nerves_uart.c
@@ -225,6 +225,52 @@ static void handle_configure(const char *req, int *req_index)
     }
 }
 
+static void handle_configuration(const char *req, int *req_index)
+{
+    char resp[256];
+    int resp_index = sizeof(uint16_t); // Space for payload size
+    resp[resp_index++] = response_id;
+    ei_encode_version(resp, &resp_index);
+
+    ei_encode_list_header(resp, &resp_index, 5);
+
+    ei_encode_tuple_header(resp, &resp_index, 2);
+    ei_encode_atom(resp, &resp_index, "speed");
+    ei_encode_long(resp, &resp_index, current_config.speed);
+
+    ei_encode_tuple_header(resp, &resp_index, 2);
+    ei_encode_atom(resp, &resp_index, "data_bits");
+    ei_encode_long(resp, &resp_index, current_config.data_bits);
+
+    ei_encode_tuple_header(resp, &resp_index, 2);
+    ei_encode_atom(resp, &resp_index, "stop_bits");
+    ei_encode_long(resp, &resp_index, current_config.stop_bits);
+
+    ei_encode_tuple_header(resp, &resp_index, 2);
+    ei_encode_atom(resp, &resp_index, "parity");
+    switch (current_config.parity) {
+    default:
+    case UART_PARITY_NONE: ei_encode_atom(resp, &resp_index, "none"); break;
+    case UART_PARITY_EVEN: ei_encode_atom(resp, &resp_index, "even"); break;
+    case UART_PARITY_ODD: ei_encode_atom(resp, &resp_index, "odd"); break;
+    case UART_PARITY_SPACE: ei_encode_atom(resp, &resp_index, "space"); break;
+    case UART_PARITY_MARK: ei_encode_atom(resp, &resp_index, "mark"); break;
+    }
+
+    ei_encode_tuple_header(resp, &resp_index, 2);
+    ei_encode_atom(resp, &resp_index, "flow_control");
+    switch (current_config.parity) {
+    default:
+    case UART_FLOWCONTROL_NONE: ei_encode_atom(resp, &resp_index, "none"); break;
+    case UART_FLOWCONTROL_HARDWARE: ei_encode_atom(resp, &resp_index, "hardware"); break;
+    case UART_FLOWCONTROL_SOFTWARE: ei_encode_atom(resp, &resp_index, "software"); break;
+    }
+
+    ei_encode_empty_list(resp, &resp_index);
+
+    erlcmd_send(resp, resp_index);
+}
+
 static void handle_close(const char *req, int *req_index)
 {
     (void) req;
@@ -490,6 +536,7 @@ static struct request_handler request_handlers[] = {
 { "drain", handle_drain },
 { "open", handle_open },
 { "configure", handle_configure },
+{ "configuration", handle_configuration },
 { "close", handle_close },
 { "signals", handle_signals },
 { "set_rts", handle_set_rts },

--- a/test/basic_uart_test.exs
+++ b/test/basic_uart_test.exs
@@ -353,11 +353,11 @@ defmodule BasicUARTTest do
   end
 
   test "opened uart returns the configuration", %{uart1: uart1} do
-    :ok = UART.open(uart1, UARTTest.port1(), active: false, speed: 57600)
+    :ok = UART.open(uart1, UARTTest.port1(), active: false, speed: 57_600)
     {name, opts} = UART.configuration(uart1)
     assert name == UARTTest.port1()
     assert Keyword.get(opts, :active) == false
-    assert Keyword.get(opts, :speed) == 57600
+    assert Keyword.get(opts, :speed) == 57_600
     UART.close(uart1)
   end
 

--- a/test/basic_uart_test.exs
+++ b/test/basic_uart_test.exs
@@ -352,6 +352,31 @@ defmodule BasicUARTTest do
     UART.close(uart1)
   end
 
+  test "opened uart returns the configuration", %{uart1: uart1} do
+    :ok = UART.open(uart1, UARTTest.port1(), active: false, speed: 57600)
+    {name, opts} = UART.configuration(uart1)
+    assert name == UARTTest.port1()
+    assert Keyword.get(opts, :active) == false
+    assert Keyword.get(opts, :speed) == 57600
+    UART.close(uart1)
+  end
+
+  test "reconfiguring the uart updates the configuration", %{uart1: uart1} do
+    :ok = UART.open(uart1, UARTTest.port1(), active: false, speed: 9600)
+    {name, opts} = UART.configuration(uart1)
+    assert name == UARTTest.port1()
+    assert Keyword.get(opts, :active) == false
+    assert Keyword.get(opts, :speed) == 9600
+
+    :ok = UART.configure(uart1, active: true, speed: 115_200)
+    {name, opts} = UART.configuration(uart1)
+    assert name == UARTTest.port1()
+    assert Keyword.get(opts, :active) == true
+    assert Keyword.get(opts, :speed) == 115_200
+
+    UART.close(uart1)
+  end
+
   # Software flow control doesn't work and I'm not sure what the deal is
   if false do
     test "xoff filtered with software flow control", %{uart1: uart1, uart2: uart2} do

--- a/test/uartless_test.exs
+++ b/test/uartless_test.exs
@@ -45,4 +45,9 @@ defmodule UARTlessTest do
     assert Keyword.get(opts, :rx_framing_timeout) == 0
     assert Keyword.get(opts, :id) == :name
   end
+
+  test "find uarts" do
+    {:ok, pid} = UART.start_link()
+    assert UART.find_pids() == [{pid, nil}]
+  end
 end

--- a/test/uartless_test.exs
+++ b/test/uartless_test.exs
@@ -31,7 +31,7 @@ defmodule UARTlessTest do
     {:ok, pid} = UART.start_link()
     {name, opts} = UART.configuration(pid)
 
-    assert name == nil
+    assert name == :closed
     assert is_list(opts)
 
     # Check the defaults
@@ -48,6 +48,6 @@ defmodule UARTlessTest do
 
   test "find uarts" do
     {:ok, pid} = UART.start_link()
-    assert UART.find_pids() == [{pid, nil}]
+    assert UART.find_pids() == [{pid, :closed}]
   end
 end

--- a/test/uartless_test.exs
+++ b/test/uartless_test.exs
@@ -26,4 +26,23 @@ defmodule UARTlessTest do
     assert {:error, :ebadf} = UART.flush(pid)
     assert {:error, :ebadf} = UART.drain(pid)
   end
+
+  test "unopened uart returns a configuration" do
+    {:ok, pid} = UART.start_link()
+    {name, opts} = UART.configuration(pid)
+
+    assert name == nil
+    assert is_list(opts)
+
+    # Check the defaults
+    assert Keyword.get(opts, :active) == true
+    assert Keyword.get(opts, :speed) == 9600
+    assert Keyword.get(opts, :data_bits) == 8
+    assert Keyword.get(opts, :stop_bits) == 1
+    assert Keyword.get(opts, :parity) == :none
+    assert Keyword.get(opts, :flow_control) == :none
+    assert Keyword.get(opts, :framing) == Nerves.UART.Framing.None
+    assert Keyword.get(opts, :rx_framing_timeout) == 0
+    assert Keyword.get(opts, :id) == :name
+  end
 end


### PR DESCRIPTION
I had an issue where I was doing a lot of Nerves.UART work via the iex prompt on a device. I started losing my UART pids and wasn't sure which UARTs to kill. I'm not sure that this is a perfect way of solving this problem, but it seems to help. Also adding a function to get the current UART's configuration seemed like a natural API to have even though I've gotten along without it for a long time.