### PR TITLE
Build with Elixir 1.7; Pull in CI updates from other projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ matrix:
     include:
         - os: linux
           compiler: gcc
-          env: ERLANG_VERSION=20.2 ELIXIR_VERSION=1.6
+          env: ERLANG_VERSION=21.0 ELIXIR_VERSION=1.7.3-otp-21
         - os: linux
           compiler: gcc
-          env: ERLANG_VERSION=18.3 ELIXIR_VERSION=1.4
+          env: ERLANG_VERSION=21.0 ELIXIR_VERSION=1.6.6-otp-21
         - os: osx
           compiler: clang
 
@@ -29,8 +29,8 @@ before_install:
         mkdir -p ~/otp && tar -xf erlang-$ERLANG_VERSION-nonroot.tar.bz2 -C ~/otp/;
         mkdir -p ~/.kerl;
         source $HOME/otp/$ERLANG_VERSION/activate;
-        wget https://github.com/elixir-lang/elixir/releases/download/v$ELIXIR_VERSION/Precompiled.zip;
-        unzip -d elixir Precompiled.zip;
+        wget https://repo.hex.pm/builds/elixir/v$ELIXIR_VERSION.zip;
+        unzip -d elixir v$ELIXIR_VERSION.zip;
         sudo chmod 666 /dev/tnt*;
         ls -las /dev/tnt*;
       else
@@ -50,5 +50,5 @@ script:
     else
       mix test test/uartless_test.exs;
     fi
-  - mix docs
-  - if (elixir -v | grep 1.6); then mix format --check-formatted; fi
+  - if (elixir -v | grep 1.7); then mix docs; mix format --check-formatted; fi
+  - mix hex.build

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Nerves.UART.MixProject do
     [
       app: :nerves_uart,
       version: @version,
-      elixir: "~> 1.4",
+      elixir: "~> 1.6",
       name: "Nerves.UART",
       description: @description,
       package: package(),
@@ -47,7 +47,7 @@ defmodule Nerves.UART.MixProject do
   defp deps() do
     [
       {:elixir_make, "~> 0.4", runtime: false},
-      {:ex_doc, "~> 0.11", only: :dev}
+      {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,8 @@
 %{
-  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
-  "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
+  "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
This change also deprecates support for Elixir 1.4 since we'll aren't testing with it any more. 

This CI updates from other project include:

* Pulling Elixir from repo.hex.pm so that we can use a precompiled version for OTP 21
* Exercise building the hex package
* Exercise building the docs
